### PR TITLE
Add sleep timeout to avoid hammering Are.na API

### DIFF
--- a/index.js
+++ b/index.js
@@ -197,12 +197,16 @@ $( document ).ready(function() {
               migrationProgress++;
             $('#progress-migration').attr('value', migrationProgress);
             $('#progress-label').text(migrationProgress + ' of ' + totalPosts + ' migrated.');
-            uploadPosts();
+            
+            // Sleep for 5 seconds to avoid hammering Are.na API
+            sleep(5000).then(() => uploadPosts());
           }).catch(function(error) {
             console.log(error);
             failureCount++;
             $('#failure-label').text(failureCount + ' failed.');
-            uploadPosts();
+            
+            // Sleep for 5 seconds to avoid hammering Are.na API
+            sleep(5000).then(() => uploadPosts());
           });
       } else {
         $('#cancel-migration').text("Finish");
@@ -232,4 +236,8 @@ $( document ).ready(function() {
     description += '\n\n__Tags__\n' + post.tags.join(', ');
     return description;
   };
+
+  const sleep = (ms) => {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+  }
 });


### PR DESCRIPTION
Hi, this is amazing! Thank you so much 👏

One thing, we rate limit our API for non-main-Are.na-client requests, so to avoid requests dropping (and to be a little kinder to our little-engine-that-could of an API), I've added a sleep function in. This will make the process take longer, and feel free to change the sleep amount but it shouldn't be any shorter than a second.

THANK YOU and well done!